### PR TITLE
Add perl special variables documentation

### DIFF
--- a/perl-special-variables.md
+++ b/perl-special-variables.md
@@ -1,0 +1,288 @@
+# Perl Special Variables
+
+Perl has many special variables that provide access to system information, process details, and runtime context. These variables are essential for effective Perl programming and script automation.
+
+## Table of Contents
+- [Default and Pattern Variables](#default-and-pattern-variables)
+- [Error and Status Variables](#error-and-status-variables)
+- [Process and System Variables](#process-and-system-variables)
+- [Input/Output Variables](#inputoutput-variables)
+- [Environment and Context Variables](#environment-and-context-variables)
+- [Regular Expression Variables](#regular-expression-variables)
+- [Array and Hash Variables](#array-and-hash-variables)
+
+## Default and Pattern Variables
+
+| Variable | Description | Example Usage |
+|----------|-------------|---------------|
+| `$_` | Default variable for many functions | `print if /pattern/;` |
+| `@_` | Arguments passed to a subroutine | `sub example { print $_[0]; }` |
+| `$1, $2, $3...` | Capture groups from regex matches | `=~/(\\w+)\\s+(\\w+)/; print "$1 $2";` |
+| `$&` | The entire matched string | `print "Matched: $&" if /pattern/;` |
+| `$`` | String before the match | `print "Before: $`" if /pattern/;` |
+| `$'` | String after the match | `print "After: $'" if /pattern/;` |
+
+### Examples:
+```perl
+# Using $_ (default variable)
+for my $line (<DATA>) {
+    print if /ERROR/;  # $_ is implicit
+}
+
+# Using subroutine arguments (@_)
+sub greet {
+    my ($name, $greeting) = @_;
+    print "$greeting, $name!\n";
+}
+greet("Alice", "Hello");
+
+# Using capture groups
+my $text = "John Doe";
+if ($text =~ /(\w+)\s+(\w+)/) {
+    print "First: $1, Last: $2\n";
+}
+```
+
+## Error and Status Variables
+
+| Variable | Description | Example Usage |
+|----------|-------------|---------------|
+| `$!` | Error message from system calls | `open my $fh, "<", "file" or die $!;` |
+| `$@` | Error message from `eval` | `eval { ... }; print $@ if $@;` |
+| `$?` | Status of last system command or backticks | `system("ls"); print "Exit code: $?\n";` |
+| `$^E` | Extended OS error (Windows) | `print "OS Error: $^E\n";` |
+
+### Examples:
+```perl
+# File operation error handling
+open my $fh, "<", "nonexistent.txt" or die "Cannot open file: $!";
+
+# eval error handling
+eval {
+    my $result = 10 / 0;
+};
+if ($@) {
+    print "Caught error: $@\n";
+}
+
+# System command status
+system("false");  # Command that returns non-zero
+print "Command failed with exit code: " . ($? >> 8) . "\n";
+```
+
+## Process and System Variables
+
+| Variable | Description | Example Usage |
+|----------|-------------|---------------|
+| `$$` | Process ID of current script | `print "PID: $$\n";` |
+| `$0` | Name of the current script | `print "Script: $0\n";` |
+| `$^O` | Operating system name | `print "OS: $^O\n";` |
+| `$^X` | Path to Perl interpreter | `print "Perl: $^X\n";` |
+| `$]` | Perl version number | `print "Version: $]\n";` |
+| `$^V` | Perl version as version object | `print "Version: $^V\n";` |
+
+### Examples:
+```perl
+# Process information
+print "Running script '$0' with PID $$ on $^O\n";
+print "Using Perl $^V at $^X\n";
+
+# Creating lock files with PID
+my $lockfile = "/tmp/script.lock.$$";
+open my $lock, ">", $lockfile or die "Cannot create lock: $!";
+print $lock "$$\n";
+close $lock;
+```
+
+## Input/Output Variables
+
+| Variable | Description | Example Usage |
+|----------|-------------|---------------|
+| `$/` | Input record separator (default `\n`) | `local $/ = undef;` |
+| `$\` | Output record separator | `$\ = "\n"; print "auto newline";` |
+| `$,` | Output field separator | `$, = ", "; print @array;` |
+| `$"` | List separator for array interpolation | `$" = ":"; print "@array";` |
+| `$.` | Current line number | `print "Line $.: $_" while <>;` |
+| `$|` | Auto-flush output buffer | `$| = 1; # Enable auto-flush` |
+
+### Examples:
+```perl
+# Reading entire file at once
+{
+    local $/ = undef;  # Slurp mode
+    my $content = <$fh>;
+    print "File size: " . length($content) . " characters\n";
+}
+
+# Custom field separators
+{
+    local $, = " | ";  # Set field separator
+    print "one", "two", "three";  # Outputs: one | two | three
+}
+
+# Line numbering
+while (<DATA>) {
+    chomp;
+    print "Line $.: $_\n";
+}
+```
+
+## Environment and Context Variables
+
+| Variable | Description | Example Usage |
+|----------|-------------|---------------|
+| `%ENV` | Environment variables hash | `print $ENV{'PATH'};` |
+| `@ARGV` | Command line arguments | `print "Args: @ARGV\n";` |
+| `$#ARGV` | Index of last element in @ARGV | `print "Arg count: " . ($#ARGV + 1);` |
+| `@INC` | Module search paths | `print "Paths: @INC\n";` |
+| `%INC` | Loaded modules hash | `print "Loaded: " . keys(%INC);` |
+
+### Examples:
+```perl
+# Environment variables
+print "User: $ENV{USER}\n" if exists $ENV{USER};
+print "Home: $ENV{HOME}\n" if exists $ENV{HOME};
+
+# Command line processing
+if (@ARGV) {
+    print "Processing " . scalar(@ARGV) . " arguments:\n";
+    for my $i (0..$#ARGV) {
+        print "  Arg $i: $ARGV[$i]\n";
+    }
+} else {
+    print "No arguments provided\n";
+}
+
+# Module information
+use Data::Dumper;
+print "Data::Dumper loaded from: $INC{'Data/Dumper.pm'}\n";
+```
+
+## Regular Expression Variables
+
+| Variable | Description | Example Usage |
+|----------|-------------|---------------|
+| `$+` | Last matched capture group | `/(a+)(b+)/; print "Last: $+";` |
+| `$^N` | Most recent capture group | Used in regex callbacks |
+| `@+` | End positions of capture groups | `print "Ends at: $+[1]";` |
+| `@-` | Start positions of capture groups | `print "Starts at: $-[1]";` |
+| `%+` | Named capture groups | `/(?\<name\>\\w+)/; print $+{name};` |
+
+### Examples:
+```perl
+# Capture group positions
+my $text = "Hello World";
+if ($text =~ /(H\w+)\s+(W\w+)/) {
+    print "Match 1: '$1' at positions $-[1]-$+[1]\n";
+    print "Match 2: '$2' at positions $-[2]-$+[2]\n";
+    print "Last capture: '$+'\n";
+}
+
+# Named captures
+if ($text =~ /(?<greeting>H\w+)\s+(?<target>W\w+)/) {
+    print "Greeting: $+{greeting}\n";
+    print "Target: $+{target}\n";
+}
+```
+
+## Array and Hash Variables
+
+| Variable | Description | Example Usage |
+|----------|-------------|---------------|
+| `$#array` | Index of last element in array | `print "Last index: $#array";` |
+| `$[` | Array base index (deprecated) | Not recommended for use |
+| `@ISA` | Inheritance array for packages | `@MyClass::ISA = qw(BaseClass);` |
+
+### Examples:
+```perl
+# Array operations
+my @fruits = qw(apple banana cherry);
+print "Array has " . ($#fruits + 1) . " elements\n";
+print "Last element: $fruits[$#fruits]\n";
+
+# Adding elements
+push @fruits, "date";
+print "Now has " . scalar(@fruits) . " elements\n";
+```
+
+## Practical Examples
+
+### Error Handling Pattern
+```perl
+sub safe_operation {
+    my ($filename) = @_;
+    
+    open my $fh, "<", $filename or do {
+        warn "Cannot open '$filename': $!";
+        return;
+    };
+    
+    my $content = do { local $/; <$fh> };
+    close $fh;
+    
+    return $content;
+}
+```
+
+### Process Management
+```perl
+# Create a unique temporary file
+my $temp_file = "/tmp/process_$$.tmp";
+print "Creating temporary file: $temp_file\n";
+
+# Signal handler using process ID
+$SIG{INT} = sub {
+    print "\nReceived interrupt signal in process $$\n";
+    unlink $temp_file if -e $temp_file;
+    exit 1;
+};
+```
+
+### Configuration Based on Environment
+```perl
+# Different behavior based on OS
+my $config = do {
+    if ($^O eq 'MSWin32') {
+        { path_sep => '\\', line_end => "\r\n" }
+    } elsif ($^O =~ /darwin|linux/) {
+        { path_sep => '/', line_end => "\n" }
+    } else {
+        { path_sep => '/', line_end => "\n" }  # Default Unix-like
+    }
+};
+
+print "Running on $^O with path separator '$config->{path_sep}'\n";
+```
+
+## Best Practices
+
+1. **Use `local` for temporary changes** to special variables:
+   ```perl
+   {
+       local $/ = "";  # Paragraph mode
+       while (<DATA>) {
+           # Process paragraphs
+       }
+   }  # $/ automatically restored
+   ```
+
+2. **Always check error variables** after system operations:
+   ```perl
+   system("important_command") == 0 or die "Command failed: $?";
+   ```
+
+3. **Use meaningful variable names** instead of special variables when possible:
+   ```perl
+   my ($name, $age) = @_;  # Better than using $_[0], $_[1]
+   ```
+
+4. **Be careful with global special variables** - they can affect other parts of your program.
+
+## Common Pitfalls
+
+- `$/` affects all file reading operations globally
+- `$|` affects all output, not just the current filehandle
+- `$_` can be modified by many functions, causing unexpected behavior
+- `@_` is aliased to actual arguments, modifications affect the original values
+
+This reference covers the most commonly used Perl special variables. Understanding these variables is crucial for writing effective Perl scripts and understanding existing Perl code.


### PR DESCRIPTION
Add `perl-special-variables.md` to provide a comprehensive reference for Perl special variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac3150c7-b9a4-4a96-8fb0-ecc54e0ba32a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac3150c7-b9a4-4a96-8fb0-ecc54e0ba32a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

